### PR TITLE
Viewpager快速切换时生命周期错乱. Fragment丢失onSupportInvisible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
 //        classpath 'com.novoda:bintray-release:0.9.2'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,11 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 29
+    compileSdkVersion = 30
     minSdkVersion = 14
-    targetSdkVersion = compileSdkVersion
+    targetSdkVersion = 26
 
-    appCompatVersion = "1.2.0-rc01"
+    appCompatVersion = "1.1.0-rc01"
 
 //    userOrg = "jantxue"
 //    groupId = "me.xuexuan"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip


### PR DESCRIPTION
解决以下bug:
luckydzp 修改 解决viewpager快速切换导致生命周期失效的问题
快速切换可能出现以下情况
fragment的visible逻辑在线程队列中还未执行 ,此时Viewpager调用fragment的invisible逻辑不成功(因fragment还未visible)
此后当fragment的visible成功后, 配对的invisible已经错失

Viewpager快速切换时生命周期错乱. Fragment丢失onSupportInvisible